### PR TITLE
refacto: update appName type in Video Service

### DIFF
--- a/src/ts/video/Service.ts
+++ b/src/ts/video/Service.ts
@@ -65,7 +65,7 @@ export class VideoService {
       `${params.data.browser.name} ${params.data.browser.version}`,
     );
     formData.append("url", params.data.url);
-    formData.append("app", params.app || "");
+    formData.append("app", params.appCode);
     formData.append("file", params.data.file, params.data.filename);
     formData.append("weight", "" + params.data.file.size);
     formData.append("captation", "" + params.captation);

--- a/src/ts/video/Service.ts
+++ b/src/ts/video/Service.ts
@@ -110,7 +110,7 @@ export class VideoService {
 
   /**
    * Generate Save Event
-   * @param app current app name
+   * @param appCode app code (example: "blog")
    * @param elapsedTime encoding elapsed time
    * @param browser browser name and version
    * @param deviceType type of device
@@ -118,7 +118,7 @@ export class VideoService {
    * @returns Promise<void>
    */
   public async generateSaveEvent(
-    appName: string | undefined,
+    appCode: string,
     elapsedTime: number,
     browser: { name: string | undefined; version: string | undefined },
     deviceType: string | undefined,
@@ -139,7 +139,7 @@ export class VideoService {
       weight: saved.videosize,
       captation: true,
       url: window.location.hostname,
-      app: appName,
+      app: appCode,
     });
   }
 }

--- a/src/ts/video/Service.ts
+++ b/src/ts/video/Service.ts
@@ -118,7 +118,7 @@ export class VideoService {
    * @returns Promise<void>
    */
   public async generateSaveEvent(
-    appName: string,
+    appName: string | undefined,
     elapsedTime: number,
     browser: { name: string | undefined; version: string | undefined },
     deviceType: string | undefined,

--- a/src/ts/video/interface.ts
+++ b/src/ts/video/interface.ts
@@ -14,7 +14,7 @@ export type VideoUploadParams = {
     filename: string;
     weight: number;
   };
-  app: string;
+  app: string | undefined;
   captation: boolean;
   duration: number;
 };

--- a/src/ts/video/interface.ts
+++ b/src/ts/video/interface.ts
@@ -14,7 +14,7 @@ export type VideoUploadParams = {
     filename: string;
     weight: number;
   };
-  app: string | undefined;
+  appCode: string;
   captation: boolean;
   duration: number;
 };


### PR DESCRIPTION
Le nom de l'application est passé via une prop dans le composant Tiptap, j'ai mis la prop optionnelle car je sais pas si un jour on l'utilisera en dehors d'une appli... du coup l'appName peut être undefined et donc j'ai dû mettre à jour le type associé