### PR TITLE
[EDIFICE] feat: simplify notify.events(), and make it easier to evolve.

### DIFF
--- a/src/ts/notify/interfaces.ts
+++ b/src/ts/notify/interfaces.ts
@@ -82,12 +82,6 @@ export interface ISubjectMessage {
   name: EventName;
   data?: any;
 }
-/** Handler of subject messages. */
-export type ISubjectSubscription<T extends ISubjectMessage> = (
-  message: T,
-) => void;
-/** Used to release an handler of subject messages. */
-export type ISubjectRevokation = () => void;
 
 /** Typing of error messages on the TRANSPORT layer. */
 //-------------------------------------
@@ -100,27 +94,34 @@ export interface IHttpErrorEvent extends ISubjectMessage {
   };
 }
 
+/** A subscription to receive ISubjectMessage */
+//-------------------------------------
+export interface ISubscription {
+  /** Close the subscription */
+  revoke: () => void;
+};
+
 export type TransportLayer = typeof LAYER_NAME.TRANSPORT;
 
-/** Generic typing of a subject. */
+/** + Generic typing of a subject. */
 //-------------------------------------
 export interface ISubject {
+  subscribe(
+    layer: Omit<LayerName, TransportLayer>,
+    handler: <T extends ISubjectMessage>(message: T) => void,
+  ): ISubscription;
   publish(
     layer: Omit<LayerName, TransportLayer>,
     message: ISubjectMessage,
   ): void;
-  subscribe(
-    layer: Omit<LayerName, TransportLayer>,
-    handler: ISubjectSubscription<ISubjectMessage>,
-  ): ISubjectRevokation;
 }
 
-/** Overloaded typing of a subject, dedicated to transport errors. */
+/** + Overloaded typing of a subject, dedicated to transport errors. */
 //-------------------------------------
 export declare interface ISubject {
   publish(layer: TransportLayer, message: IHttpErrorEvent): void;
   subscribe(
     layer: TransportLayer,
-    handler: ISubjectSubscription<IHttpErrorEvent>,
-  ): ISubjectRevokation;
+    handler: (message: IHttpErrorEvent) => void,
+  ): ISubscription;
 }

--- a/src/ts/transport/Service.ts
+++ b/src/ts/transport/Service.ts
@@ -18,14 +18,12 @@ export class HttpService implements IHttp {
   private baseUrl?: string;
   private headers: Record<string, string> = {};
   private _latestResponse: any;
-  private channel: BroadcastChannel;
 
   constructor(
     private context: IOdeServices,
     params?: any,
   ) {
     this.axios = axios.create(params);
-    this.channel = notify.events().newChannel(LAYER_NAME.TRANSPORT);
   }
 
   private fixBaseUrl(url: string) {
@@ -174,14 +172,15 @@ export class HttpService implements IHttp {
 
     // Notify errors unless explicitely disabled.
     params?.disableNotifications ||
-      this.channel.postMessage({
+    notify.events().publish(LAYER_NAME.TRANSPORT, {
         name: EVENT_NAME.ERROR_OCCURED,
         data: {
           params,
           response: { status, statusText, headers },
           payload: data,
         },
-      });
+      }
+    );
 
     return data;
   }


### PR DESCRIPTION
The `events()` system of INotifyFramework was exposing an API with 2 levels of access : from inside ts-client, and from outside.
This PR exposes only 1 level, which becomes the de-facto events system for all.

Provides
- Simpler typings
- `ISubscription` modeled, which could evolve later (for example, if a publisher+receiver does not want to receive its own messages)